### PR TITLE
Add Kubernetes Manifests

### DIFF
--- a/.k8s/deployment.yaml
+++ b/.k8s/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: af-reservation
+  labels:
+    app: assignforce
+    service: reservation
+spec:
+  selector:
+    matchLabels:
+      service: reservation
+  template:
+    metadata:
+      labels:
+        service: reservation
+    spec:
+      containers:
+        - name: af-reservation
+          image: 855430746673.dkr.ecr.us-east-1.amazonaws.com/af-reservation-service:fc4072833cc91ffdb1bf9f5a39d4013fcd343818
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: res-http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "750m"
+              memory: "1500m"
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /actuator/health
+            failureThreshold: 2
+            periodSeconds: 20
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /actuator/health
+            successThreshold: 3
+            failureThreshold: 2
+            periodSeconds: 30
+            timeoutSeconds: 2

--- a/.k8s/service.yaml
+++ b/.k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: af-reservation-svc
+  labels:
+    app: assignforce
+spec:
+  ports:
+    - port: 10000
+      targetPort: res-http
+      protocol: TCP
+  selector:
+    service: reservation

--- a/reservation-service/pom.xml
+++ b/reservation-service/pom.xml
@@ -44,7 +44,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>


### PR DESCRIPTION
* Added a `Deployment` for the `af-reservation-service`
* Added a `Service` of type `ClusterIP` to route traffic from port 10000 to the `Pod`'s port 8080
* Added the `spring-boot-starter-actuator` Maven dependency to enable proper liveness/readiness probes