### PR TITLE
Added an `Ingress` Controller for Reservation API

### DIFF
--- a/.k8s/deployment.yaml
+++ b/.k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: af-reservation
-          image: 855430746673.dkr.ecr.us-east-1.amazonaws.com/af-reservation-service:fc4072833cc91ffdb1bf9f5a39d4013fcd343818
+          image: 855430746673.dkr.ecr.us-east-1.amazonaws.com/af-reservation-service:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -24,12 +24,13 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: "750m"
-              memory: "1500m"
+              cpu: "500m"
+              memory: "1G"
           readinessProbe:
             httpGet:
               port: 8080
               path: /actuator/health
+            successThreshold: 3
             failureThreshold: 2
             periodSeconds: 20
             timeoutSeconds: 2
@@ -37,7 +38,6 @@ spec:
             httpGet:
               port: 8080
               path: /actuator/health
-            successThreshold: 3
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 2

--- a/.k8s/ingress.yaml
+++ b/.k8s/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: af-reservation-ing
+  labels:
+    app: assignforce
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /reservation/(.+)
+            backend:
+              serviceName: af-reservation-svc
+              servicePort: res-svc-http

--- a/.k8s/service.yaml
+++ b/.k8s/service.yaml
@@ -9,5 +9,6 @@ spec:
     - port: 10000
       targetPort: res-http
       protocol: TCP
+      name: res-svc-http
   selector:
     service: reservation


### PR DESCRIPTION
* Configured the `Ingress` to capture everything after the `/reservation` URI and send to the API
* Added a `Service` port name to enable routing from `Ingress` to `Service`
* Removed the successThreshold from `livenessProbe` and added to `readinessProbe`